### PR TITLE
Refactor book admin module for SOLID-friendly permissions and genre handling

### DIFF
--- a/CleanArchitecture.Presentation/admin/src/app/(admin)/book/detail/[id]/page.tsx
+++ b/CleanArchitecture.Presentation/admin/src/app/(admin)/book/detail/[id]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useGetApiV1BooksId } from "@/lib/api/books/books";
@@ -10,13 +9,14 @@ import {
 } from "@/lib/utils/error-handler";
 import ComponentCard from "@/components/common/ComponentCard";
 import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import { useBookPermissions } from "@/hooks/useBookPermissions";
+import { getGenreLabel } from "@/lib/books/genre";
 
 export default function BookDetailPage() {
   const params = useParams<{ id: string }>();
   const bookId = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
-  const { data: session } = useSession();
-  const canEdit = (session?.user?.roles ?? []).includes("edit");
+  const { canEdit } = useBookPermissions();
 
   const { data: response, error, isLoading } = useGetApiV1BooksId(bookId ?? "", {
     query: {
@@ -53,7 +53,7 @@ export default function BookDetailPage() {
             </div>
             <div>
               <h4 className="text-sm font-medium text-gray-500 dark:text-gray-400">Genre</h4>
-              <p className="text-lg font-semibold text-gray-800 dark:text-white/90">{book.genre}</p>
+              <p className="text-lg font-semibold text-gray-800 dark:text-white/90">{getGenreLabel(book.genre)}</p>
             </div>
             <div>
               <h4 className="text-sm font-medium text-gray-500 dark:text-gray-400">ID</h4>

--- a/CleanArchitecture.Presentation/admin/src/app/(admin)/book/list/page.tsx
+++ b/CleanArchitecture.Presentation/admin/src/app/(admin)/book/list/page.tsx
@@ -5,6 +5,7 @@ import { getAuthOptions } from "@/app/api/auth/[...nextauth]/route";
 import { Metadata } from "next";
 import { getServerSession } from "next-auth";
 import Link from "next/link";
+import { hasRole } from "@/lib/auth/permissions";
 
 export const metadata: Metadata = {
   title: "Books List | Clean Architecture Admin",
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
 
 export default async function BookListPage() {
   const session = await getServerSession(getAuthOptions());
-  const canCreate = (session?.user?.roles ?? []).includes("create");
+  const canCreate = hasRole(session?.user?.roles, "create");
 
   return (
     <div>

--- a/CleanArchitecture.Presentation/admin/src/components/book/BookForm.tsx
+++ b/CleanArchitecture.Presentation/admin/src/components/book/BookForm.tsx
@@ -23,12 +23,7 @@ import Label from "../form/Label";
 import Input from "../form/input/InputField";
 import Button from "../ui/button/Button";
 import { bookSchema, type BookFormValues } from "@/lib/validations/book";
-
-const genreOptions = [
-  { value: "F", label: "Fiction" },
-  { value: "NF", label: "Non-Fiction" },
-  { value: "M", label: "Mystery" },
-] as const;
+import { genreOptions } from "@/lib/books/genre";
 
 const fieldErrorMap = {
   Title: "title",

--- a/CleanArchitecture.Presentation/admin/src/components/book/BookTable.tsx
+++ b/CleanArchitecture.Presentation/admin/src/components/book/BookTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useState } from "react";
 import {
@@ -15,6 +14,8 @@ import {
   formatErrorMessages,
 } from "@/lib/utils/error-handler";
 import { useModal } from "@/hooks/useModal";
+import { useBookPermissions } from "@/hooks/useBookPermissions";
+import { getGenreLabel } from "@/lib/books/genre";
 import Button from "../ui/button/Button";
 import { Modal } from "../ui/modal";
 import {
@@ -27,13 +28,10 @@ import {
 
 export default function BookTable() {
   const queryClient = useQueryClient();
-  const { data: session } = useSession();
   const { data: response, error, isLoading } = useGetApiV1Books();
   const { isOpen, openModal, closeModal } = useModal();
   const [bookToDelete, setBookToDelete] = useState<BookResponse | null>(null);
-  const roles = session?.user?.roles ?? [];
-  const canEdit = roles.includes("edit");
-  const canDelete = roles.includes("delete");
+  const { canEdit, canDelete } = useBookPermissions();
 
   const books =
     response?.status === 200 && response.data.isSuccess && Array.isArray(response.data.value?.items)
@@ -124,7 +122,7 @@ export default function BookTable() {
                     {book.title}
                   </TableCell>
                   <TableCell className="px-5 py-4 text-sm text-gray-800 dark:text-white/90">
-                    {book.genre}
+                    {getGenreLabel(book.genre)}
                   </TableCell>
                   <TableCell className="px-5 py-4 text-sm text-gray-800 dark:text-white/90">
                     <div className="flex items-center gap-3">

--- a/CleanArchitecture.Presentation/admin/src/hooks/useBookPermissions.ts
+++ b/CleanArchitecture.Presentation/admin/src/hooks/useBookPermissions.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { hasRole } from "@/lib/auth/permissions";
+
+export function useBookPermissions() {
+  const { data: session } = useSession();
+  const roles = session?.user?.roles;
+
+  return {
+    canCreate: hasRole(roles, "create"),
+    canEdit: hasRole(roles, "edit"),
+    canDelete: hasRole(roles, "delete"),
+  };
+}

--- a/CleanArchitecture.Presentation/admin/src/lib/auth/permissions.ts
+++ b/CleanArchitecture.Presentation/admin/src/lib/auth/permissions.ts
@@ -1,0 +1,14 @@
+export const BOOK_ROLES = ["create", "edit", "delete"] as const;
+
+export type BookRole = (typeof BOOK_ROLES)[number];
+
+export function hasRole(
+  roles: readonly string[] | undefined,
+  requiredRole: BookRole,
+): boolean {
+  if (!roles?.length) {
+    return false;
+  }
+
+  return roles.includes(requiredRole);
+}

--- a/CleanArchitecture.Presentation/admin/src/lib/books/genre.ts
+++ b/CleanArchitecture.Presentation/admin/src/lib/books/genre.ts
@@ -1,0 +1,16 @@
+const genreLabelByValue = {
+  F: "Fiction",
+  NF: "Non-Fiction",
+  M: "Mystery",
+} as const;
+
+export type BookGenre = keyof typeof genreLabelByValue;
+
+export const genreOptions = Object.entries(genreLabelByValue).map(([value, label]) => ({
+  value: value as BookGenre,
+  label,
+}));
+
+export function getGenreLabel(genre: string): string {
+  return genreLabelByValue[genre as BookGenre] ?? genre;
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated inline authorization and genre-translation logic spread across pages/components by centralizing those responsibilities. 
- Improve maintainability and extensibility following SOLID principles (SRP, OCP, DIP) so adding roles or genres requires changes in one place.

### Description
- Added a small permission utility `src/lib/auth/permissions.ts` that exports `hasRole` and the `BookRole` type to centralize role checks. 
- Introduced a client hook `src/hooks/useBookPermissions.ts` that reads session roles and exposes `canCreate`, `canEdit`, and `canDelete` so UI components depend on a single permission abstraction. 
- Centralized genre metadata and helpers in `src/lib/books/genre.ts` exposing `genreOptions`, `BookGenre` and `getGenreLabel` for UI consistency and reuse. 
- Updated book-related UI to use the new abstractions by modifying `BookForm.tsx`, `BookTable.tsx`, and the book `list`/`detail` pages to remove duplicated `roles.includes(...)` checks and inline genre strings in favor of the shared utilities.

### Testing
- Ran `npm run lint` in the `CleanArchitecture.Presentation/admin` package and the lint run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0da940c1c832f89cca42cd12d0a58)