### PR TITLE
feat: introduce repository pattern for book management and refactor u…

### DIFF
--- a/CleanArchitecture.Application/CleanArchitecture.Application.csproj
+++ b/CleanArchitecture.Application/CleanArchitecture.Application.csproj
@@ -11,11 +11,11 @@
     <PackageReference Include="DomainValidation.NET" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Mediator.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Mediator.SourceGenerator">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Scriban">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/CleanArchitecture.Application/Common/IApplicationUnitOfWork.cs
+++ b/CleanArchitecture.Application/Common/IApplicationUnitOfWork.cs
@@ -15,12 +15,9 @@ public interface IUnitOfWork
 }
 
 /// <summary>
-/// Represents an application-specific unit of work that includes specific DbSets.
+/// Represents an application-specific unit of work that includes entity repositories.
 /// </summary>
 public interface IApplicationUnitOfWork : IUnitOfWork
 {
-    /// <summary>
-    /// Gets the DbSet for <see cref="Book"/> entities.
-    /// </summary>
-    public DbSet<Book> Books { get; }
+    public IBookRepository Books { get; }
 }

--- a/CleanArchitecture.Application/Common/IBookRepository.cs
+++ b/CleanArchitecture.Application/Common/IBookRepository.cs
@@ -1,0 +1,45 @@
+namespace CleanArchitecture.Application.Common;
+
+/// <summary>
+/// Defines the contract for a repository that manages book entities.
+/// </summary>
+public interface IBookRepository
+{
+    /// <summary>
+    /// Retrieves a book by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the book to retrieve.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the book if found; otherwise, null.</returns>
+    Task<Book?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the total count of books in the repository.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the total number of books.</returns>
+    Task<int> CountAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a paginated list of books.
+    /// </summary>
+    /// <param name="skip">The number of records to skip before starting to yield results.</param>
+    /// <param name="take">The maximum number of records to return.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a read-only list of books.</returns>
+    Task<IReadOnlyList<Book>> GetPagedAsync(int skip, int take, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a new book to the repository.
+    /// </summary>
+    /// <param name="book">The book entity to add.</param>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddAsync(Book book, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes an existing book from the repository.
+    /// </summary>
+    /// <param name="book">The book entity to remove.</param>
+    void Remove(Book book);
+}

--- a/CleanArchitecture.Application/Entities/Books/Commands/Create/CreateBookCommandHandler.cs
+++ b/CleanArchitecture.Application/Entities/Books/Commands/Create/CreateBookCommandHandler.cs
@@ -23,7 +23,7 @@ internal class CreateBookCommandHandler(IApplicationUnitOfWork applicationUnitOf
             return Result<Guid>.Failure(book.Errors.ToArray());
         }
 
-        await applicationUnitOfWork.Books.AddAsync(book!, cancellationToken).ConfigureAwait(false);
+        await applicationUnitOfWork.Books.AddAsync(book.Value!, cancellationToken).ConfigureAwait(false);
 
         Result result = await applicationUnitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/CleanArchitecture.Application/Entities/Books/Commands/Delete/DeleteBookCommandHandler.cs
+++ b/CleanArchitecture.Application/Entities/Books/Commands/Delete/DeleteBookCommandHandler.cs
@@ -7,7 +7,7 @@ internal class DeleteBookRequestHandler(IApplicationUnitOfWork applicationUnitOf
 {
     protected override async Task<Result> HandleRequest(DeleteBookCommand request, CancellationToken cancellationToken)
     {
-        Book? book = await applicationUnitOfWork.Books.FindAsync(keyValues: [request.Id], cancellationToken).ConfigureAwait(false);
+        Book? book = await applicationUnitOfWork.Books.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);
 
         if (book is null)
         {

--- a/CleanArchitecture.Application/Entities/Books/Commands/Update/UpdateBookCommandHandler.cs
+++ b/CleanArchitecture.Application/Entities/Books/Commands/Update/UpdateBookCommandHandler.cs
@@ -7,7 +7,7 @@ internal class UpdateBookRequestHandler(IApplicationUnitOfWork applicationUnitOf
 {
     protected override async Task<Result> HandleRequest(UpdateBookCommand request, CancellationToken cancellationToken)
     {
-        Book? book = await applicationUnitOfWork.Books.FindAsync(keyValues: [request.Id], cancellationToken).ConfigureAwait(false);
+        Book? book = await applicationUnitOfWork.Books.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false);
 
         if (book is null)
         {

--- a/CleanArchitecture.Application/Entities/Books/Queries/Get/GetBookQueryHandler.cs
+++ b/CleanArchitecture.Application/Entities/Books/Queries/Get/GetBookQueryHandler.cs
@@ -8,8 +8,7 @@ internal class GetBookQueryHandler(IApplicationUnitOfWork applicationUnitOfWork,
     protected override async Task<Result<BookResponse>> HandleRequest(GetBookQuery request, CancellationToken cancellationToken)
     {
         Book? book = await applicationUnitOfWork.Books
-            .AsNoTracking()
-            .FirstOrDefaultAsync(b => b.Id == request.Id, cancellationToken)
+            .GetByIdAsync(request.Id, cancellationToken)
             .ConfigureAwait(false);
 
         return book is null

--- a/CleanArchitecture.Application/Entities/Books/Queries/Get/GetBooksQueryHandler.cs
+++ b/CleanArchitecture.Application/Entities/Books/Queries/Get/GetBooksQueryHandler.cs
@@ -11,18 +11,16 @@ internal class GetBooksQueryHandler(IApplicationUnitOfWork applicationUnitOfWork
         int pageSize = Math.Clamp(request.PageSize, 1, MaxPageSize);
 
         int totalCount = await applicationUnitOfWork.Books
-            .AsNoTracking()
             .CountAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        List<BookResponse> items = await applicationUnitOfWork.Books
-            .AsNoTracking()
-            .OrderBy(b => b.Title)
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .Select(book => new BookResponse(book.Id, book.Title, book.Genre))
-            .ToListAsync(cancellationToken)
+        IReadOnlyList<Book> books = await applicationUnitOfWork.Books
+            .GetPagedAsync((page - 1) * pageSize, pageSize, cancellationToken)
             .ConfigureAwait(false);
+
+        List<BookResponse> items = books
+            .Select(book => new BookResponse(book.Id, book.Title, book.Genre))
+            .ToList();
 
         PaginatedResponse<BookResponse> response = new(items, page, pageSize, totalCount);
 

--- a/CleanArchitecture.Application/GlobalUsings.cs
+++ b/CleanArchitecture.Application/GlobalUsings.cs
@@ -4,7 +4,6 @@ global using FluentValidation;
 global using System.Globalization;
 global using FluentValidation.Results;
 global using Microsoft.Extensions.Logging;
-global using Microsoft.EntityFrameworkCore;
 global using CleanArchitecture.Domain.Entities;
 global using CleanArchitecture.Application.Errors;
 global using CleanArchitecture.Application.Common;

--- a/CleanArchitecture.Infrastructure.Persistence/Data/Repositories/BookRepository.cs
+++ b/CleanArchitecture.Infrastructure.Persistence/Data/Repositories/BookRepository.cs
@@ -1,0 +1,25 @@
+namespace CleanArchitecture.Infrastructure.Persistence.Data.Repositories;
+
+internal sealed class BookRepository(ApplicationDbContext context) : IBookRepository
+{
+    public Task<Book?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        => context.Set<Book>().FindAsync([id], cancellationToken).AsTask();
+
+    public Task<int> CountAsync(CancellationToken cancellationToken = default)
+        => context.Set<Book>().AsNoTracking().CountAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<Book>> GetPagedAsync(int skip, int take, CancellationToken cancellationToken = default)
+        => await context.Set<Book>()
+            .AsNoTracking()
+            .OrderBy(b => b.Title)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task AddAsync(Book book, CancellationToken cancellationToken = default)
+        => await context.Set<Book>().AddAsync(book, cancellationToken).ConfigureAwait(false);
+
+    public void Remove(Book book)
+        => context.Set<Book>().Remove(book);
+}

--- a/CleanArchitecture.Infrastructure.Persistence/Data/UnitOfWork/ApplicationUnitOfWork.DbSets.cs
+++ b/CleanArchitecture.Infrastructure.Persistence/Data/UnitOfWork/ApplicationUnitOfWork.DbSets.cs
@@ -2,5 +2,5 @@
 
 public sealed partial class ApplicationUnitOfWork
 {
-    public DbSet<Book> Books => context.Set<Book>();
+    public IBookRepository Books => bookRepository;
 }

--- a/CleanArchitecture.Infrastructure.Persistence/Data/UnitOfWork/ApplicationUnitOfWork.cs
+++ b/CleanArchitecture.Infrastructure.Persistence/Data/UnitOfWork/ApplicationUnitOfWork.cs
@@ -9,7 +9,7 @@ namespace CleanArchitecture.Infrastructure.Persistence.Data.UnitOfWork;
 /// </summary>
 /// <param name="context">The application database context.</param>
 /// <param name="logger">The logger instance.</param>
-public sealed partial class ApplicationUnitOfWork(ApplicationDbContext context, ILogger<ApplicationUnitOfWork> logger) : IApplicationUnitOfWork
+public sealed partial class ApplicationUnitOfWork(ApplicationDbContext context, IBookRepository bookRepository, ILogger<ApplicationUnitOfWork> logger) : IApplicationUnitOfWork
 {
     /// <summary>
     /// Saves the changes asynchronously.

--- a/CleanArchitecture.Infrastructure.Persistence/DependencyInjection.cs
+++ b/CleanArchitecture.Infrastructure.Persistence/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using CleanArchitecture.Infrastructure.Persistence.Data;
 using CleanArchitecture.Infrastructure.Persistence.Data.UnitOfWork;
 using CleanArchitecture.Infrastructure.Persistence.Data.Interceptors;
+using CleanArchitecture.Infrastructure.Persistence.Data.Repositories;
 
 namespace CleanArchitecture.Infrastructure.Persistence;
 
@@ -36,6 +37,7 @@ public static class DependencyInjection
                 builder.MigrationsAssembly(typeof(ApplicationDbContext).Assembly.FullName));
         });
 
+        services.AddScoped<IBookRepository, BookRepository>();
         services.AddScoped<IApplicationUnitOfWork, ApplicationUnitOfWork>();
 
         services.AddSingleton(TimeProvider.System);

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="3.1.1" />


### PR DESCRIPTION
- Added `IBookRepository` interface and its implementation `BookRepository` to encapsulate book-related database operations.
- Refactored `ApplicationUnitOfWork` to replace `DbSet<Book>` with `IBookRepository` for better abstraction.
- Updated various command and query handlers (`CreateBookCommandHandler`, `GetBookQueryHandler`, etc.) to use the new repository methods.
- Simplified pagination and querying logic by introducing reusable repository methods like `GetByIdAsync` and `GetPagedAsync`.
- Registered `IBookRepository` in dependency injection and adjusted related configurations.
- Removed unnecessary `Microsoft.EntityFrameworkCore` references in application layer and centralized package management for .NET 10 dependencies.